### PR TITLE
Refactor CLI Flag Parsing for Enhanced Command Flexibility

### DIFF
--- a/cmd/tsstest/main.go
+++ b/cmd/tsstest/main.go
@@ -22,45 +22,47 @@ import (
 	"github.com/voltix-vault/mobile-tss-lib/tss"
 )
 
+func commonFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:    "server",
+			Aliases: []string{"s"},
+			Usage:   "server address",
+			Value:   "http://127.0.0.1:8080",
+		},
+		&cli.StringFlag{
+			Name:       "key",
+			Aliases:    []string{"k"},
+			Usage:      "something to uniquely identify local party",
+			Required:   true,
+			HasBeenSet: false,
+			Hidden:     false,
+		},
+		&cli.StringSliceFlag{
+			Name:       "parties",
+			Aliases:    []string{"p"},
+			Usage:      "comma separated list of party keys, need to have all the keys of the keygen committee",
+			Required:   true,
+			HasBeenSet: false,
+			Hidden:     false,
+		},
+		&cli.StringFlag{
+			Name:       "session",
+			Usage:      "current communication session",
+			Required:   true,
+			HasBeenSet: false,
+			Hidden:     false,
+		},
+	}
+}
 func main() {
 	app := cli.App{
 		Name:  "tss-test",
 		Usage: "tss-test is a tool for testing tss library.",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "server",
-				Aliases: []string{"s"},
-				Usage:   "server address",
-				Value:   "http://127.0.0.1:8080",
-			},
-			&cli.StringFlag{
-				Name:       "key",
-				Aliases:    []string{"k"},
-				Usage:      "something to uniquely identify local party",
-				Required:   true,
-				HasBeenSet: false,
-				Hidden:     false,
-			},
-			&cli.StringSliceFlag{
-				Name:       "parties",
-				Aliases:    []string{"p"},
-				Usage:      "comma separated list of party keys, need to have all the keys of the keygen committee",
-				Required:   true,
-				HasBeenSet: false,
-				Hidden:     false,
-			},
-			&cli.StringFlag{
-				Name:       "session",
-				Usage:      "current communication session",
-				Required:   true,
-				HasBeenSet: false,
-				Hidden:     false,
-			},
-		},
 		Commands: []*cli.Command{
 			{
 				Name: "keygen",
-				Flags: []cli.Flag{
+				Flags: append(commonFlags(),
 					&cli.StringFlag{
 						Name:       "chaincode",
 						Aliases:    []string{"cc"},
@@ -68,13 +70,12 @@ func main() {
 						Required:   true,
 						HasBeenSet: false,
 						Hidden:     false,
-					},
-				},
+					}),
 				Action: runCmd,
 			},
 			{
 				Name: "reshare",
-				Flags: []cli.Flag{
+				Flags: append(commonFlags(),
 					&cli.StringFlag{
 						Name:       "chaincode",
 						Aliases:    []string{"cc"},
@@ -111,17 +112,17 @@ func main() {
 						Required:   false,
 						HasBeenSet: false,
 						Hidden:     false,
-					},
-				},
+					}),
 				Action: reshareCmd,
 			},
 			{
 				Name:   "chaincode",
 				Action: generateChainCode,
+				Flags:  commonFlags(),
 			},
 			{
 				Name: "sign",
-				Flags: []cli.Flag{
+				Flags: append(commonFlags(),
 					&cli.StringFlag{
 						Name:       "pubkey",
 						Aliases:    []string{"pk"},
@@ -142,13 +143,12 @@ func main() {
 						Name:     "derivepath",
 						Usage:    "derive path for bitcoin, e.g. m/84'/0'/0'/0/0",
 						Required: true,
-					},
-				},
+					}),
 				Action: keysignCmd,
 			},
 			{
 				Name: "signEDDSA",
-				Flags: []cli.Flag{
+				Flags: append(commonFlags(),
 					&cli.StringFlag{
 						Name:       "pubkey",
 						Aliases:    []string{"pk"},
@@ -164,8 +164,7 @@ func main() {
 						Required:   true,
 						HasBeenSet: false,
 						Hidden:     false,
-					},
-				},
+					}),
 				Action: keysignEDDSACmd,
 			},
 		},


### PR DESCRIPTION
## Overview
This PR refactors the way CLI flags are parsed and handled, allowing a more intuitive flag placement when invoking commands. By centralizing common flag definitions and allowing them to be recognized within the command context, we make our CLI tool more user-friendly and aligned with common Unix CLI practices.

## Changes
- Introduced a `commonFlags()` helper function to consolidate the definitions of flags commonly used across multiple commands.
- Updated the command structure to support flag parsing both at the application level and within individual commands.
- This allows for greater flexibility in command usage, adhering to more standard CLI conventions.

## Current vs New Usage
Previously, flags needed to be specified before the command name:

`go run main.go --key "key1" --parties "parties" keygen`

With this PR, flags can be used more flexibly, either before or after the command name:

`go run main.go keygen --key "key1" --parties "parties"
`
